### PR TITLE
Order the options predictably

### DIFF
--- a/python-scripts/launch.py
+++ b/python-scripts/launch.py
@@ -36,32 +36,33 @@ The format will be <option> : [<script_name>, <function_name>.
 An eg: to build DPDK ivshmem is looks like
 BUILD_DPDK_IVSHM : [build_script.sh, build_dpdk_ivshm]
 """
-BASH_SCRIPT_FNS = {
-                   "CLEAN-TEST-SYSTEM": ["clean_test.sh", "clean"],
-                   "PHY-PHY-VANILA-TEST": ["phy2phy_stockovs.sh", "menu"],
-                   "PHY-PHY-TEST": ["phy2phy_manual.sh", "menu"],
-                   "PHY-PHY-BOND-TEST": ["phy2phy-bond-bidir.sh", "menu"],
-                   "PHY-VXLAN-PHY-TEST": ["phy2phy_vxlan-bidir.sh", "menu"],
-                   "PHY-VXLAN-PHY-noENCAP-TEST": ["phy2phy_vxlan-bidir-no-encap-traffic.sh", "menu"],
-                   "PHY-VM-PHY-TEST": ["phy2vm_manual.sh", "menu"],
+BASH_SCRIPT_FNS = collections.OrderedDict ([
+                   ("CLEAN-TEST-SYSTEM", ["clean_test.sh", "clean"]),
+                   ("PHY-PHY-VANILA-TEST", ["phy2phy_stockovs.sh", "menu"]),
+                   ("PHY-PHY-TEST", ["phy2phy_manual.sh", "menu"]),
+                   ("PHY-PHY-BOND-TEST", ["phy2phy-bond-bidir.sh", "menu"]),
+                   ("PHY-VXLAN-PHY-TEST", ["phy2phy_vxlan-bidir.sh", "menu"]),
+                   ("PHY-VXLAN-PHY-noENCAP-TEST", ["phy2phy_vxlan-bidir-no-encap-traffic.sh", "menu"]),
+                   ("PHY-VM-PHY-TEST", ["phy2vm_manual.sh", "menu"]),
                    #Just build with existing config settings
-                   "BUILD-OVS-NO-CLEAN": ["build_script.sh", "build_ovs_default"],
-                   "BUILD-OVS-GDB-DPDK-NATIVE": ["build_script.sh", "build_ovs_gdb"],
-                   "BUILD-OVS-DPDK-NATIVE": ["build_script.sh", "build_ovs"],
-                   "BUILD-OVS-DPDK-IVSHM": ["build_script.sh", "build_ovs_ivshm"],
-                   "BUILD-VANILA-OVS": ["build_script.sh", "build_vanila_ovs"],
-                   "BUILD-OVS+DPDK-PERF-GDB": ["build_script.sh", "build_ovs_and_dpdk_gdb_perf"],
+                   ("BUILD-OVS-NO-CLEAN", ["build_script.sh", "build_ovs_default"]),
+                   ("BUILD-OVS-GDB-DPDK-NATIVE", ["build_script.sh", "build_ovs_gdb"]),
+                   ("BUILD-OVS-DPDK-NATIVE", ["build_script.sh", "build_ovs"]),
+                   ("BUILD-OVS-DPDK-IVSHM", ["build_script.sh", "build_ovs_ivshm"]),
+                   ("BUILD-VANILA-OVS", ["build_script.sh", "build_vanila_ovs"]),
+                   ("BUILD-OVS+DPDK-PERF-GDB", ["build_script.sh", "build_ovs_and_dpdk_gdb_perf"]),
                    # build the OVS with /var and /usr prefix than /usr/local
-                   "BUILD-VANILA-OVS-PREFIX": ["build_script.sh", "build_vanila_ovs_prefix"],
-                   "BUILD-DPDK-NATIVE": ["build_script.sh", "build_dpdk"],
-                   "BUILD-DPDK-GDB": ["build_script.sh", "build_dpdk_gdb"],
-                   "OVS-SANITY-UT": ["build_script.sh", "build_check"],
-                   "OVS-PURGE-CLEAN": ["build_script.sh", "clean_repo"],
+                   ("BUILD-VANILA-OVS-PREFIX", ["build_script.sh", "build_vanila_ovs_prefix"]),
+                   ("BUILD-DPDK-NATIVE", ["build_script.sh", "build_dpdk"]),
+                   ("BUILD-DPDK-GDB", ["build_script.sh", "build_dpdk_gdb"]),
+                   ("OVS-SANITY-UT", ["build_script.sh", "build_check"]),
+                   ("OVS-PURGE-CLEAN", ["build_script.sh", "clean_repo"]),
                    # Leave the script field empty when fn is python local.
-                   "DEFINE-ALL-ENV" : ["", "set_and_save_env"],
-                   "DEFINE-ONE-ENV" : ["", "set_and_save_selected_env"],
-                   "START-SUBSHELL" : ["", "start_bash_shell"]
-                   }
+                   ("DEFINE-ALL-ENV" , ["", "set_and_save_env"]),
+                   ("DEFINE-ONE-ENV" , ["", "set_and_save_selected_env"]),
+                   ("START-SUBSHELL" , ["", "start_bash_shell"])
+                   ])
+
 def print_color_string(s, color='white'):
     print("%s" %(colored(s, color, attrs = ['bold'])))
 


### PR DESCRIPTION
Use an OrderedDict instead of a regular dict to keep the list of
options ordered logically and stop them being re-arranged.

Signed-off-by: Billy O'Mahony <billy.omahony@gmail.com>