### PR TITLE
launch.py: improve env var format

### DIFF
--- a/bash-scripts/clean_test.sh
+++ b/bash-scripts/clean_test.sh
@@ -12,6 +12,7 @@ function clean {
     #std_clean
     std_stop_ovs
     std_stop_db
+    std_stop_vms
 
     echo "System cleaned for next test run"
 }

--- a/bash-scripts/multicast.sh
+++ b/bash-scripts/multicast.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -x
+
+SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. ${SRC_DIR}/std_funcs.sh
+
+# Variables #
+NUM_VHOST_IFACES=4
+
+function start_test {
+
+    set_dpdk_env
+    std_start_db
+    std_start_ovs
+
+    sudo $OVS_DIR/utilities/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
+
+    std_create_ifaces $NUM_VHOST_IFACES   # writes to global STD_IFACT_TO_PORT
+
+    echo "Setting up OF rules.."
+    set -e #fail if i/f name -> of port mapping does not exist
+    sudo $OVS_DIR/utilities/ovs-ofctl del-flows br0
+    #sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_0]},action=output:${STD_IFACE_TO_PORT[dpdk_1]}
+    #sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_1]},action=output:${STD_IFACE_TO_PORT[dpdk_0]}
+    #sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_0]},action=in_port
+    #sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_1]},action=in_port
+    sudo $OVS_DIR/utilities/ovs-ofctl dump-flows br0
+    set +e
+
+    echo "Starting VMs.."
+    for idx in $(seq 0 $[$NUM_VHOST_IFACES-1])
+    do
+        std_start_vm $idx
+    done
+
+    echo "Current state.."
+    set -x
+    sudo $OVS_DIR/utilities/ovs-vsctl show
+    sudo $OVS_DIR/utilities/ovs-ofctl dump-ports br0
+    sudo $OVS_DIR/utilities/ovs-ofctl show br0
+    sudo $OVS_DIR/utilities/ovs-appctl vlog/set ANY info
+    set +x
+
+    echo "All done."
+	return
+}
+
+function menu {
+        echo "launching Switch.."
+        start_test
+}
+
+#The function has to get called only when its in subshell.
+if [ "$OVS_RUN_SUBSHELL" == "1" ]; then
+    menu
+fi

--- a/bash-scripts/multicast.sh
+++ b/bash-scripts/multicast.sh
@@ -23,6 +23,7 @@ function start_test {
     #sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_1]},action=output:${STD_IFACE_TO_PORT[dpdk_0]}
     #sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_0]},action=in_port
     #sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_1]},action=in_port
+    sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 action=NORMAL
     sudo $OVS_DIR/utilities/ovs-ofctl dump-flows br0
     set +e
 

--- a/bash-scripts/phy2phy_manual.sh
+++ b/bash-scripts/phy2phy_manual.sh
@@ -15,18 +15,6 @@ function start_test {
     set_dpdk_env
     std_umount
     std_mount
-
-    #sudo umount $HUGE_DIR
-    #echo "Lets bind the ports to the kernel first"
-    #sudo $DPDK_BIND_TOOL --bind=$KERNEL_NIC_DRV $DPDK_PCI1 $DPDK_PCI2
-    #mkdir -p $HUGE_DIR
-    #sudo mount -t hugetlbfs nodev $HUGE_DIR
-
-    sudo modprobe uio
-    sudo rmmod igb_uio.ko
-    sudo insmod $DPDK_IGB_UIO
-    sudo $DPDK_BIND_TOOL --bind=igb_uio $DPDK_PCI1 $DPDK_PCI2
-
     std_start_db
 
     sudo $OVS_DIR/utilities/ovs-vsctl --no-wait init
@@ -36,39 +24,33 @@ function start_test {
     sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-hugepage-dir="$HUGE_DIR"
     sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask="$PMD_CPU_MASK"
     sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:emc-insert-inv-prob=100          #x => insert 1 per x times, 1 => always. Special 0 => never.
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-extra="-w 0000:07:00.0 -w 0000:07:00.1 --file-prefix=ovs_"
+    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-extra="$STD_WHITELIST --file-prefix=ovs_"
 
     sudo -E $OVS_DIR/vswitchd/ovs-vswitchd --pidfile unix:/usr/local/var/run/openvswitch/db.sock --log-file &
     sleep 22
+
     sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 del-br br0
     sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-br br0 -- set bridge br0 datapath_type=netdev
-    sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-port br0 $DPDK_NIC1 \
-		-- set Interface $DPDK_NIC1 type=dpdk \
-		options:dpdk-devargs=$DPDK_PCI1 options:n_rxq=2
-    sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-port br0 $DPDK_NIC2 \
-		-- set Interface $DPDK_NIC2 type=dpdk \
-		options:dpdk-devargs=$DPDK_PCI2 options:n_rxq=2
+    std_create_ifaces 0
+    #sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-port br0 $DPDK_NIC1 \
+		#-- set Interface $DPDK_NIC1 type=dpdk \
+		#options:dpdk-devargs=$DPDK_PCI1 options:n_rxq=2
+    #sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-port br0 $DPDK_NIC2 \
+		#-- set Interface $DPDK_NIC2 type=dpdk \
+		#options:dpdk-devargs=$DPDK_PCI2 options:n_rxq=2
 
     sudo $OVS_DIR/utilities/ovs-ofctl del-flows br0
-    sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=1,action=output:2
-    sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=2,action=output:1
-    #sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=2,dl_dst=03:00:00:00:00:03,nw_dst=192.168.2.101,action=output:1
+    sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_0]},action=output:${STD_IFACE_TO_PORT[dpdk_1]}
+    sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_1]},action=output:${STD_IFACE_TO_PORT[dpdk_0]}
     sudo $OVS_DIR/utilities/ovs-ofctl dump-flows br0
     sudo $OVS_DIR/utilities/ovs-ofctl dump-ports br0
     sudo $OVS_DIR/utilities/ovs-vsctl show
     echo "Finished setting up the bridge, ports and flows..."
 }
 
-function kill_switch {
-    echo "Stopping OvS"
-    std_stop_ovs
-    std_stop_db
-	return
-}
 
 function menu {
         echo "launching Switch.."
-        kill_switch
         start_test
 }
 

--- a/bash-scripts/phy2phy_manual.sh
+++ b/bash-scripts/phy2phy_manual.sh
@@ -5,10 +5,6 @@ SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . ${SRC_DIR}/std_funcs.sh
 echo $OVS_DIR $DPDK_DIR
 
-# Variables #
-HUGE_DIR=/dev/hugepages
-
-
 function start_test {
 
     print_phy2phy_banner
@@ -16,28 +12,9 @@ function start_test {
     std_umount
     std_mount
     std_start_db
+    std_start_ovs
 
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait init
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=$DPDK_LCORE_MASK
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem=$DPDK_SOCKET_MEM
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-hugepage-dir="$HUGE_DIR"
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask="$PMD_CPU_MASK"
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:emc-insert-inv-prob=100          #x => insert 1 per x times, 1 => always. Special 0 => never.
-    sudo $OVS_DIR/utilities/ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-extra="$STD_WHITELIST --file-prefix=ovs_"
-
-    sudo -E $OVS_DIR/vswitchd/ovs-vswitchd --pidfile unix:/usr/local/var/run/openvswitch/db.sock --log-file &
-    sleep 22
-
-    sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 del-br br0
-    sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-br br0 -- set bridge br0 datapath_type=netdev
     std_create_ifaces 0
-    #sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-port br0 $DPDK_NIC1 \
-		#-- set Interface $DPDK_NIC1 type=dpdk \
-		#options:dpdk-devargs=$DPDK_PCI1 options:n_rxq=2
-    #sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-port br0 $DPDK_NIC2 \
-		#-- set Interface $DPDK_NIC2 type=dpdk \
-		#options:dpdk-devargs=$DPDK_PCI2 options:n_rxq=2
 
     sudo $OVS_DIR/utilities/ovs-ofctl del-flows br0
     sudo $OVS_DIR/utilities/ovs-ofctl add-flow br0 idle_timeout=0,in_port=${STD_IFACE_TO_PORT[dpdk_0]},action=output:${STD_IFACE_TO_PORT[dpdk_1]}
@@ -47,7 +24,6 @@ function start_test {
     sudo $OVS_DIR/utilities/ovs-vsctl show
     echo "Finished setting up the bridge, ports and flows..."
 }
-
 
 function menu {
         echo "launching Switch.."

--- a/bash-scripts/std_funcs.sh
+++ b/bash-scripts/std_funcs.sh
@@ -8,6 +8,13 @@ declare DPDK_IGB_UIO
 declare DPDK_BIND_TOOL
 declare -A STD_IFACE_TO_PORT # map "iface_name" -> openflow port no
 
+# Create STD_WHITELIST and STD_NICS from comma/space separated string DPDK_NICS
+declare -a STD_NICS         #STD_NICS is an array
+IFS=', ' read -r -a STD_NICS <<< "$DPDK_NICS"
+NUM_DPDK_IFACES=${#STD_NICS[@]}
+STD_WHITELIST=""                 # -w NIC1 -w NIC2 ...
+for nic in ${NICS[@]}; do STD_WHITELIST="$STD_WHITELIST -w $nic"; done
+
 # Some settings that don't change often enough to warrant being in the env file
 declare DPDK_SOCKET_MEM="1024,1024"
 declare DPDK_LCORE_MASK="0x1"
@@ -83,9 +90,6 @@ function std_clean {
 function std_create_ifaces() {
     VHOST_IFACE_NAME_BASE=vhu_
     DPDK_IFACE_NAME_BASE=dpdk_
-    # Turn comma/space separated string into array
-    IFS=', ' read -r -a STD_NICS <<< "$DPDK_NICS"
-    NUM_DPDK_IFACES=${#STD_NICS[@]}
     port_no=1
     #declare -A STD_IFACE_TO_PORT # map "iface_name" -> openflow port no
 

--- a/bash-scripts/std_funcs.sh
+++ b/bash-scripts/std_funcs.sh
@@ -54,7 +54,7 @@ function std_bind_kernel() {
 }
 
 function std_stop_vms() {
-    sudo pkill -9 qemu-system-x86_64*
+    sudo pkill qemu
 }
 
 function std_clean {

--- a/bash-scripts/std_funcs.sh
+++ b/bash-scripts/std_funcs.sh
@@ -8,10 +8,10 @@ declare DPDK_IGB_UIO
 declare DPDK_BIND_TOOL
 declare -A STD_IFACE_TO_PORT # map "iface_name" -> openflow port no
 
-# Create STD_WHITELIST and STD_NICS from comma/space separated string DPDK_NICS
-declare -a STD_NICS         #STD_NICS is an array
-IFS=', ' read -r -a STD_NICS <<< "$DPDK_NICS"
-NUM_DPDK_IFACES=${#STD_NICS[@]}
+# Create STD_WHITELIST and STD_PCIS from comma/space separated string DPDK_PCIS
+declare -a STD_PCIS         #STD_PCIS is an array
+IFS=', ' read -r -a STD_PCIS <<< "$DPDK_PCIS"
+NUM_DPDK_IFACES=${#STD_PCIS[@]}
 STD_WHITELIST=""                 # -w NIC1 -w NIC2 ...
 for nic in ${NICS[@]}; do STD_WHITELIST="$STD_WHITELIST -w $nic"; done
 
@@ -113,7 +113,7 @@ function std_clean {
 
 
 
-# creates a dpdk interface for each pci device in STD_NICS array and a number of
+# creates a dpdk interface for each pci device in STD_PCIS array and a number of
 # vhuclient ifaces based on $1 arg.
 #
 # $1 the number of vhostuserclient ifaces to create
@@ -133,7 +133,7 @@ function std_create_ifaces() {
         IFACE_NAME="${DPDK_IFACE_NAME_BASE}${idx}"
         sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10  add-port br0 $IFACE_NAME \
 		    -- set Interface $IFACE_NAME type=dpdk \
-            options:dpdk-devargs=${STD_NICS[$idx]}     \
+            options:dpdk-devargs=${STD_PCIS[$idx]}     \
             options:n_rxq=1                        \
 			ofport_request=$port_no
         STD_IFACE_TO_PORT[$IFACE_NAME]=$port_no

--- a/bash-scripts/std_funcs.sh
+++ b/bash-scripts/std_funcs.sh
@@ -34,7 +34,7 @@ std_start_db() {
 }
 
 function std_stop_db() {
-    sudo $OVS_DIR/utilities/ovs-appctl --timeout=3 -t ovsdb-server exit
+    sudo $OVS_DIR/utilities/ovs-appctl --timeout=3 -t ovsdb-server exit 2> /dev/null
     sleep 1
     sudo pkill -9 ovsdb-server
 }
@@ -74,7 +74,7 @@ function std_start_ovs() {
 }
 
 function std_stop_ovs() {
-    sudo $OVS_DIR/utilities/ovs-appctl --timeout=3 -t ovs-vswitchd exit
+    sudo $OVS_DIR/utilities/ovs-appctl --timeout=3 -t ovs-vswitchd exit 2> /dev/null
     sleep 1
     sudo rm -rf /usr/local/var/log/openvswitch/*
     sudo rm -rf /usr/local/var/run/openvswitch/*

--- a/bash-scripts/std_funcs.sh
+++ b/bash-scripts/std_funcs.sh
@@ -3,10 +3,15 @@
 # This file contains a place to put standard code that is common across several
 # test scripts. All the functions should be called std_...
 
+# Globals that various std functions will populate
 declare DPDK_IGB_UIO
 declare DPDK_BIND_TOOL
-declare DPDK_SOCKET_MEM="4096,4096"
-declare DPDK_LCORE_MASK="0x4"
+declare -A STD_IFACE_TO_PORT # map "iface_name" -> openflow port no
+
+# Some settings that don't change often enough to warrant being in the env file
+declare DPDK_SOCKET_MEM="1024,1024"
+declare DPDK_LCORE_MASK="0x1"
+declare VHU_SOCK_DIR=/tmp
 
 # Load the ovs schema and start ovsdb.
 std_start_db() {
@@ -64,6 +69,85 @@ function std_clean {
     std_umount
 }
 
+
+
+# creates a dpdk interface for each pci device in STD_NICS array and a number of
+# vhuclient ifaces based on $1 arg.
+#
+# $1 the number of vhostuserclient ifaces to create
+#
+# OUT creates STD_IFACE_TO_PORT # map "iface_name" -> openflow port no
+#     e.g. use ${IFACE_TO_PORT[dpdk_0]} in ofctl cmds as OF port num of
+#     first NIC port
+
+function std_create_ifaces() {
+    VHOST_IFACE_NAME_BASE=vhu_
+    DPDK_IFACE_NAME_BASE=dpdk_
+    # Turn comma/space separated string into array
+    IFS=', ' read -r -a STD_NICS <<< "$DPDK_NICS"
+    NUM_DPDK_IFACES=${#STD_NICS[@]}
+    port_no=1
+    #declare -A STD_IFACE_TO_PORT # map "iface_name" -> openflow port no
+
+    for idx in $(seq 0 $[$NUM_DPDK_IFACES-1])
+    do
+        IFACE_NAME="${DPDK_IFACE_NAME_BASE}${idx}"
+        sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10  add-port br0 $IFACE_NAME \
+		    -- set Interface $IFACE_NAME type=dpdk \
+            options:dpdk-devargs=${STD_NICS[$idx]}     \
+            options:n_rxq=1                        \
+			ofport_request=$port_no
+        STD_IFACE_TO_PORT[$IFACE_NAME]=$port_no
+        port_no=$[$port_no+1]
+    done
+
+    # options:dpdk-lsc-interrupt=true        \
+
+    for idx in $(seq 0 $[$NUM_VHOST_IFACES-1])
+    do
+        IFACE_NAME="${VHOST_IFACE_NAME_BASE}${idx}"
+        sudo $OVS_DIR/utilities/ovs-vsctl --timeout 10 add-port br0 $IFACE_NAME \
+          -- set Interface $IFACE_NAME type=dpdkvhostuserclient   \
+            options:vhost-server-path="${VHU_SOCK_DIR}/${IFACE_NAME}" \
+			ofport_request=$port_no
+        STD_IFACE_TO_PORT[$IFACE_NAME]=$port_no
+        port_no=$[$port_no+1]
+    done
+}
+
+
+function std_start_vm() {
+    # $1 the number of the vm to start. This is used as an index to determine
+    #     many things about the vm: name, vhu server socket, admin ssh port etc.
+
+    id=$(printf "%d" $1)
+    idhex=$(printf "%02X" $1)
+
+    VM_NAME=us-vhost-vm_$id
+    VHU_SOCK_NAME=vhu_${id}
+    VHOST_MAC=00:00:00:00:01:$idhex
+    SSH_PORT=$[2000 + $1]
+    NUM_CORES=2
+    MEM=2G
+
+    sudo -E taskset -c 3-13 $QEMU_DIR/x86_64-softmmu/qemu-system-x86_64 \
+      -name $VM_NAME -cpu host -enable-kvm -m $MEM \
+      -object memory-backend-file,id=mem,size=$MEM,mem-path=$HUGE_DIR,share=on \
+      -numa node,memdev=mem -mem-prealloc -smp $NUM_CORES \
+      -drive file=$VM_IMAGE \
+      \
+      -chardev socket,id=char0,path=$VHU_SOCK_DIR/$VHU_SOCK_NAME,server \
+      -netdev type=vhost-user,id=mynet1,chardev=char0,vhostforce \
+      -device virtio-net-pci,mac=${VHOST_MAC},netdev=mynet1,mrg_rxbuf=off \
+      \
+      -net nic \
+      -net user,id=ctlnet,net=20.0.0.0/8,host=20.0.0.1,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22 \
+      -vnc :${id},password \
+      -snapshot -daemonize
+
+    echo "ssh to VM $1 with 'ssh -p $SSH_PORT <vm-user>@localhost"
+}
+
 ####################################
 #  DPDK specific functions         #
 ####################################
@@ -76,8 +160,6 @@ set_dpdk_env() {
         DPDK_BIND_TOOL=$(find $DPDK_DIR -name dpdk_nic_bind.py | head -1 )
     fi
 
-    export DPDK_SOCKET_MEM
-    export DPDK_LCORE_MASK
     echo "Found igb_uio: " $DPDK_IGB_UIO
     echo "Found dpdk bind: " $DPDK_BIND_TOOL
     $DPDK_BIND_TOOL --status-dev net

--- a/bash-scripts/vm.sh
+++ b/bash-scripts/vm.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. ${SRC_DIR}/../../.ovs-dpdk-script-env
+. ${SRC_DIR}/std_funcs.sh
+
+function ifup() {
+    set -x
+	LOCAL_IP=192.168.8.$[10 + ${VM_ID}]
+	ssh -p $SSH_PORT ubuntu@localhost bash -c "'
+        sudo ip addr add ${LOCAL_IP}/24 dev eth2
+        sudo ip link set dev eth2 up
+        echo "Done."
+    '"
+    set +x
+}
+
+function mcast() {
+    set -x
+	LOCAL_IP=192.168.8.$[10 + ${VM_ID}]
+	ssh -p $SSH_PORT ubuntu@localhost bash -c "'
+        sudo ip link set eth2 multicast on
+        sudo pkill smcrouted
+        sudo smcroute -d -f smcroute.conf
+        sudo sysctl net.ipv4.icmp_echo_ignore_broadcasts=0
+        echo "Done."
+    '"
+    set +x
+}
+
+function join() {
+    set -x
+	ssh -p $SSH_PORT ubuntu@localhost bash -c "'
+        sudo smcroutectl join eth2 225.1.2.3
+    '"
+    set +x
+}
+
+function leave() {
+    set -x
+	ssh -p $SSH_PORT ubuntu@localhost bash -c "'
+        sudo smcroutectl leave eth2 225.1.2.3
+    '"
+    set +x
+}
+
+function ls_() {
+    set -x
+	ssh -p $SSH_PORT ubuntu@localhost bash -c "'
+        sudo ls
+    '"
+    set +x
+}
+
+function usage() {
+    echo "Usage: $0 <vm_number> start|if_up|mcast|join|leave"
+    echo "   vm_number starts from 0"
+}
+
+if [[ $# != 2 || ! ("$1" =~ ^[0-9]+$) ]]; then
+    echo "Bad number of params or can't parse <vm_number>"
+    usage
+    exit 1
+fi
+
+VM_ID=$(printf "%d" $1)
+VM_ID_HEX=$(printf "%02X" $1)
+
+# Rather than require specification of lots of rarely changing options in calls
+# to std_funcs change behaviour by overriding env vars e.g.
+# VM_IMAGE=/opt/billy/pri-path-u14.04.fka-vloop.qcow2
+# MEM=2G
+# VM_NAME=us-vhost-vm_$id
+# NUM_CORES=2
+# TODO naming convention STD_ARG_VM_MEM ??
+
+# TODO The base ssh port number should really be exported from std_funcs
+SSH_PORT=$[2000 + ${VM_ID}]
+# TODO naming convention STD_VM_SSH_BASE_PORT ??
+
+case $2 in
+    start)
+        std_start_vm $VM_ID
+        ;;
+    ifup|if_up)
+        ifup
+        ;;
+    mcast)
+        mcast
+        ;;
+    join)
+        join
+        ;;
+    leave)
+        leave
+        ;;
+    ls)
+        ls_
+        ;;
+    *)
+        echo "'$2' - Bad cmd param"
+        usage
+        exit 1
+        ;;
+esac

--- a/python-scripts/launch.py
+++ b/python-scripts/launch.py
@@ -19,7 +19,7 @@ ENV_DICT = collections.OrderedDict ([
     ("DPDK_DIR", ""),
     ("DPDK_NIC1", ""),
     ("DPDK_NIC2", ""),
-    ("DPDK_NICS", ""),
+    ("DPDK_PCIS", ""),
     ("DPDK_PCI1", ""),
     ("DPDK_PCI2", ""),
     ("DPDK_PCI3", ""),

--- a/python-scripts/launch.py
+++ b/python-scripts/launch.py
@@ -15,25 +15,25 @@ except ImportError:
         return string_
 
 # Holds all the environment settings that needed for OVS-DPDK scripts
-ENV_DICT = {
-            "OVS_DIR" : "",
-            "DPDK_DIR" : "",
-            "QEMU_DIR" : "",
-            "VM_IMAGE" : "",
-            "DPDK_NIC1" : "",
-            "DPDK_NIC2" : "",
-            "DPDK_PCI1" : "",
-            "DPDK_PCI2" : "",
-            "DPDK_PCI3" : "",
-            "DPDK_PCI4" : "",
-            "VHOST_NIC1" : "",
-            "VHOST_NIC2" : "",
-            "VHOST_MAC1" : "",
-            "VHOST_MAC2" : "",
-            "KERNEL_NIC_DRV" : "",
-            "DPDK_TARGET" : "",
-            "PMD_CPU_MASK" : "",
-            }
+ENV_DICT = collections.OrderedDict ([
+    ("DPDK_DIR", ""),
+    ("DPDK_NIC1", ""),
+    ("DPDK_NIC2", ""),
+    ("DPDK_PCI1", ""),
+    ("DPDK_PCI2", ""),
+    ("DPDK_PCI3", ""),
+    ("DPDK_PCI4", ""),
+    ("DPDK_TARGET", ""),
+    ("DPDK_VER", ""),
+    ("KERNEL_NIC_DRV", ""),
+    ("OVS_DIR", ""),
+    ("PMD_CPU_MASK", ""),
+    ("QEMU_DIR", ""),
+    ("VHOST_MAC1", ""),
+    ("VHOST_MAC2", ""),
+    ("VHOST_NIC1", ""),
+    ("VHOST_NIC2", ""),
+    ("VM_IMAGE", "")])
 ENV_FILE_NAME = ".ovs-dpdk-script-env"
 
 """
@@ -147,12 +147,11 @@ def read_and_display_env():
     for line in env_fp.readlines():
         if not line:
             continue
-        if line.startswith("#"):
-                # Comment line , do nothing.
-	    continue
-	if ":-" not in line:
+        if line.strip().find("export") > 0:
+            # Line does not begin with 'export'
             continue
-        (key, value) = line.split(':-')
+        (tmp, value) = line.split('=')
+        (export, key) = tmp.split(' ')
 
         if not (key and value):
             print_color_string("Something went wrong in file, its corrupted",
@@ -162,6 +161,7 @@ def read_and_display_env():
         if not key in ENV_DICT:
             print_color_string("Invalid key in the file, corrupted file",
                                color = 'red')
+            print("%s=%s\n" % (str(key), str(value)))
             continue
 
         ENV_DICT[key] = value.strip('\n')
@@ -170,7 +170,7 @@ def read_and_display_env():
     env_fp = open(env_, 'w')
     for key, value in ENV_DICT.iteritems():
         #print_color_string(key + " :- " + value + "\n", color='green')
-        env_fp.write(str(key) + ":-" + str(value) + "\n")
+        env_fp.write("export %s=%s\n" % (str(key), str(value)))
 
     env_fp.close()
     return True
@@ -202,7 +202,8 @@ def set_and_save_selected_env():
         if key == key_in:
             data = raw_input("Enter new value to update %s: " %key_in)
             value = data.strip()
-        env_fp.write(str(key) + ":-" + str(value) + "\n")
+        env_fp.write("export %s=%s\n" % (str(key), str(value)))
+        #env_fp.write(str(key) + ":-" + str(value) + "\n")
 
     env_fp.close()
     read_and_display_env()
@@ -222,7 +223,8 @@ def set_and_save_env():
         data = raw_input(key + "=" + value + ": ")
         if data:
             value = data.strip()
-        env_fp.write(str(key) + ":-" + str(value) + "\n")
+        env_fp.write("export %s=%s\n" % (str(key), str(value)))
+        #env_fp.write(str(key) + ":-" + str(value) + "\n")
 
     env_fp.close()
 

--- a/python-scripts/launch.py
+++ b/python-scripts/launch.py
@@ -47,6 +47,7 @@ BASH_SCRIPT_FNS = collections.OrderedDict ([
                    ("CLEAN-TEST-SYSTEM", ["clean_test.sh", "clean"]),
                    #("PRIPATH-TEST", ["pp.sh", "menu"]),
                    ("VM-VM-TEST", ["vm2vm_manual.sh", "menu"]),
+                   ("MULTICAST", ["multicast.sh", "menu"]),
                    ("PHY-PHY-VANILA-TEST", ["phy2phy_stockovs.sh", "menu"]),
                    ("PHY-PHY-TEST", ["phy2phy_manual.sh", "menu"]),
                    #("PVP-2PHY-2VHOST-TEST", ["phy2vm_manual.sh", "menu"]),

--- a/python-scripts/launch.py
+++ b/python-scripts/launch.py
@@ -19,6 +19,7 @@ ENV_DICT = collections.OrderedDict ([
     ("DPDK_DIR", ""),
     ("DPDK_NIC1", ""),
     ("DPDK_NIC2", ""),
+    ("DPDK_NICS", ""),
     ("DPDK_PCI1", ""),
     ("DPDK_PCI2", ""),
     ("DPDK_PCI3", ""),


### PR DESCRIPTION
Make the env var file a source-able bash script making it quick to use the same
env for test script and for an interactive bash shell. Also keep the env vars
in alpabetical order.